### PR TITLE
Fix #162

### DIFF
--- a/common/src/main/resources/data/medievalorigins/origins/arachnae.json
+++ b/common/src/main/resources/data/medievalorigins/origins/arachnae.json
@@ -8,6 +8,7 @@
                 "medievalorigins:arachnae/bottomless_stomach",
                 "medievalorigins:arachnae/brittle",
                 "medievalorigins:arachnae/fragile_exoskeleton",
+		"origins:carnivore",
                 "origins:master_of_webs",
                 "origins:arthropod"
 	],


### PR DESCRIPTION
Gives Arachnae the `origins:carnivore` tag that was previously missing. Other origins seem to have unique tags with their own special flavor text, but this is the best I can do for now.